### PR TITLE
feat(SprayExploitFixer): Bump to 2.23

### DIFF
--- a/spray_exploit_fixer.sp
+++ b/spray_exploit_fixer.sp
@@ -351,8 +351,8 @@ public void OnClientDisconnect(int client)
 	g_smChecked.Remove(g_sPath2[client]);
 	g_smReceive.Remove(g_sPath2[client]);
 
-	FormatEx(g_sAuth[client], sizeof(g_sAuth[]), "");
-	FormatEx(g_sAuthUnverified[client], sizeof(g_sAuthUnverified[]), "");
+	FormatEx(g_sAuth[client], sizeof(g_sAuth[]), "\0");
+	FormatEx(g_sAuthUnverified[client], sizeof(g_sAuthUnverified[]), "\0");
 
 	/*
 	static char sPath[PLATFORM_MAX_PATH];

--- a/spray_exploit_fixer.sp
+++ b/spray_exploit_fixer.sp
@@ -18,7 +18,7 @@
 
 
 
-#define PLUGIN_VERSION 		"2.22"
+#define PLUGIN_VERSION 		"2.23"
 
 /*=======================================================================================
 	Plugin Info:
@@ -31,6 +31,15 @@
 
 ========================================================================================
 	Change Log:
+
+2.23 (01-Nov-2024)
+	- Now only TestClient depending cvar
+	- Now ban lenght can be adjusted via cvar
+	- Now less check of GetClientAuthId by storing them.
+	- Switch to Steam3 format for AuthID.
+	- Fixed g_smWaiting not removing data for unverified clients.
+	- Prevent g_smWaiting not removing data if client was already disconnected.
+	- LogAction now print infos even if client is not verified.
 
 2.22 (28-Jan-2024)
 	- Fixed memory leak caused by clearing StringMap/ArrayList data instead of deleting.
@@ -180,8 +189,10 @@ char g_sMoveFiles[PLATFORM_MAX_PATH];
 char g_sDownloads[PLATFORM_MAX_PATH];
 char g_sPath1[MAXPLAYERS+1][PLATFORM_MAX_PATH];
 char g_sPath2[MAXPLAYERS+1][PLATFORM_MAX_PATH];
+char g_sAuth[MAXPLAYERS+1][64];
+char g_sAuthUnverified[MAXPLAYERS+1][64];
 float g_fSprayed[MAXPLAYERS+1];
-ConVar g_hCvarBan, g_hCvarKick, g_hCvarLog, g_hCvarMsg, g_hCvarPath;
+ConVar g_hCvarBan, g_hCvarBanTime, g_hCvarKick, g_hCvarLog, g_hCvarMsg, g_hCvarPath, g_hCvarPunish;
 EngineVersion g_iEngine;
 StringMap g_smChecked;
 StringMap g_smReceive;
@@ -260,10 +271,12 @@ public void OnPluginStart()
 	}
 
 	CreateConVar(					"spray_exploit_fixer",			PLUGIN_VERSION,		"Spray Exploit Fixer plugin version.", FCVAR_DONTRECORD);
+	g_hCvarPunish 	= CreateConVar(		"spray_exploit_fixer_punish_client",	"0",		"0=Off. 1=PlayerDecal. 2=FileCheck. 3=Both. Run the TestClient function");
 	if( g_iEngine != Engine_TF2 )
 	{
 		g_hCvarBan = CreateConVar(	"spray_exploit_fixer_ban",		"0",				"0=Off. 1=Ban users who trigger invalid sprays (may still be some false positives).");
 		g_hCvarKick = CreateConVar(	"spray_exploit_fixer_kick",		"0",				"0=Off. 1=Kick users who trigger invalid sprays (may still be some false positives).");
+		g_hCvarBanTime 	= CreateConVar( "spray_exploit_fixer_bantime",  "5", 				"0=Perm. Ban time (in minutes)");
 	}
 	g_hCvarLog = CreateConVar(		"spray_exploit_fixer_log",		"1",				"Logging saved to sourcemod/logs/spray_downloads.log: 0=Off. 1=Log all user uploads. 2=Log invalid sprays only.");
 	g_hCvarMsg = CreateConVar(		"spray_exploit_fixer_msg",		"1",				"Print to server console: 0=Off. 1=Missing sprays and invalid sprays. 2=Only invalid sprays.");
@@ -310,6 +323,17 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	return Plugin_Continue;
 }
 
+public void OnClientPutInServer(int client)
+{
+	char sSteamID[64];
+	GetClientAuthId(client, AuthId_Steam3, sSteamID, sizeof(sSteamID));
+	FormatEx(g_sAuth[client], sizeof(g_sAuth[]), "%s", sSteamID);
+
+	char sSteamIDUnverified[32];
+	GetClientAuthId(client, AuthId_Steam3, sSteamIDUnverified, sizeof(sSteamIDUnverified), false);
+	FormatEx(g_sAuthUnverified[client], sizeof(g_sAuthUnverified[]), "%s", sSteamIDUnverified);
+}
+
 public void OnClientConnected(int client)
 {
 	g_fSprayed[client] = 0.0;
@@ -320,18 +344,15 @@ public void OnClientConnected(int client)
 public void OnClientDisconnect(int client)
 {
 	if( IsFakeClient(client) ) return;
-
-	if( IsClientConnected(client) )
-	{
-		static char auth[32];
-		GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
-		g_smWaiting.Remove(auth);
-	}
-
+	
+	g_smWaiting.Remove(g_sAuthUnverified[client]);
 	g_smChecked.Remove(g_sPath1[client]);
 	g_smReceive.Remove(g_sPath1[client]);
 	g_smChecked.Remove(g_sPath2[client]);
 	g_smReceive.Remove(g_sPath2[client]);
+
+	FormatEx(g_sAuth[client], sizeof(g_sAuth[]), "");
+	FormatEx(g_sAuthUnverified[client], sizeof(g_sAuthUnverified[]), "");
 
 	/*
 	static char sPath[PLATFORM_MAX_PATH];
@@ -739,13 +760,11 @@ Action PlayerDecal(const char[] te_name, const int[] Players, int numClients, fl
 
 	if( !val )
 	{
-		static char auth[32];
-		GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth));
-		if( strncmp(auth[6], "ID_", 3) == 0 )
-		{
-			GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
-			Format(auth, sizeof(auth), "Unverified: %s", auth);
-		}
+		static char auth[64];
+		if ( g_sAuth[client][6] == 'I' )
+			Format(auth, sizeof(auth), "Unverified: %s", g_sAuthUnverified[client]);
+		else
+			Format(auth, sizeof(auth), "%s", g_sAuth[client]);
 
 		if( FileExists(g_sFilename) )
 		{
@@ -756,14 +775,16 @@ Action PlayerDecal(const char[] te_name, const int[] Players, int numClients, fl
 				if( g_hCvarMsg.IntValue ) PrintToServer("[Spray Exploit] Blocked invalid spray: %s from (%N) [%s]", g_sFilename, client, auth);
 			}
 
-			TestClient(client);
+			if( g_hCvarPunish.IntValue == 1 || g_hCvarPunish.IntValue >= 3)
+				TestClient(client);
 		}
 		else
 		{
-			if( GetGameTime() - g_fSprayed[client] > TIMEOUT_LOG && !g_smWaiting.GetValue(auth, val) )
+			if( GetGameTime() - g_fSprayed[client] > TIMEOUT_LOG && !g_smWaiting.GetValue(g_sAuthUnverified[client], val) )
 			{
 				g_fSprayed[client] = GetGameTime();
-				g_smWaiting.SetValue(auth, true);
+				g_smWaiting.SetValue(g_sAuthUnverified[client], true);
+
 				if( g_hCvarLog.IntValue ) LogCustom("Blocked unchecked spray - missing file: %s from (%N) [%s]", g_sFilename, client, auth);
 				if( g_hCvarMsg.IntValue == 1 ) PrintToServer("[Spray Exploit] Blocked unchecked spray - missing file: %s from (%N) [%s]", g_sFilename, client, auth);
 			}
@@ -847,26 +868,23 @@ void TestClient(int client)
 	{
 		if( g_hCvarBan.IntValue )
 		{
+			int iDuration = g_hCvarBanTime.IntValue;
+
 			if( g_bSourceBans )
-			{
-				SBPP_BanPlayer(0, client, 0, "Invalid spray");
-				LogAction(client, -1, "[Spray Exploit] %L Banned for invalid Spray", client);
-			}
+				SBPP_BanPlayer(0, client, iDuration, "Invalid spray");
 			else if( g_bMaterialAdmin )
-			{
-				MABanPlayer(0, client, MA_BAN_STEAM, 0, "Invalid spray");
-				LogAction(client, -1, "[Spray Exploit] %L Banned for invalid Spray", client);
-			}
+				MABanPlayer(0, client, MA_BAN_STEAM, iDuration, "Invalid spray");
 			else
-			{
-				BanClient(client, 0, BANFLAG_AUTO, "Invalid spray");
-				LogAction(client, -1, "[Spray Exploit] %L Banned for invalid Spray", client);
-			}
+				BanClient(client, iDuration, BANFLAG_AUTO, "Invalid spray");
+
+			LogAction(client, -1, "[Spray Exploit] %N %s was banned %d minutes for invalid Spray", client, g_sAuthUnverified[client], iDuration);
+			return;
 		}
 		else if( g_hCvarKick.IntValue )
 		{
-			KickClient(client, "Invalid spray");
-			LogAction(client, -1, "[Spray Exploit] %L kicked for invalid Spray", client);
+			KickClient(client, "Invalid spray. Please change it");
+			LogAction(client, -1, "[Spray Exploit] %N %s was kicked for invalid Spray.", client, g_sAuthUnverified[client]);
+			return;
 		}
 	}
 }
@@ -909,13 +927,11 @@ public Action OnFileReceive(int client, const char[] sFile)
 	{
 		if( client )
 		{
-			static char auth[32];
-			GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth));
-			if( strncmp(auth[6], "ID_", 3) == 0 )
-			{
-				GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
-				Format(auth, sizeof(auth), "Unverified: %s", auth);
-			}
+			static char auth[64];
+			if ( g_sAuth[client][6] == 'I' )
+				Format(auth, sizeof(auth), "Unverified: %s", g_sAuthUnverified[client]);
+			else
+				Format(auth, sizeof(auth), "%s", g_sAuth[client]);
 
 			LogCustom("File received: %s from (%N) [%s]", sFile, client, auth);
 		}
@@ -975,13 +991,11 @@ void FileCheck()
 					if( !client ) client = GetClientFromJingle();
 					if( client )
 					{
-						static char auth[32];
-						GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth));
-						if( strncmp(auth[6], "ID_", 3) == 0 )
-						{
-							GetClientAuthId(client, AuthId_Steam2, auth, sizeof(auth), false);
-							Format(auth, sizeof(auth), "Unverified: %s", auth);
-						}
+						static char auth[64];
+						if ( g_sAuth[client][6] == 'I' )
+							Format(auth, sizeof(auth), "Unverified: %s", g_sAuthUnverified[client]);
+						else
+							Format(auth, sizeof(auth), "%s", g_sAuth[client]);
 
 						if( g_hCvarLog.IntValue ) LogCustom("Invalid spray: %s from (%N) [%s]", g_sFilename, client, auth);
 						if( g_hCvarMsg.IntValue ) PrintToServer("[Spray Exploit] Invalid spray: %s: %02d (%02X <> %02X) from (%N) [%s]", g_sFilename, i, iRead[i], g_iVal[i], client, auth);
@@ -990,7 +1004,8 @@ void FileCheck()
 						if( g_hCvarMsg.IntValue ) PrintToServer("[Spray Exploit] Invalid spray: %s: %02d (%02X <> %02X)", g_sFilename, i, iRead[i], g_iVal[i]);
 					}
 
-					TestClient(client);
+					if( g_hCvarPunish.IntValue >= 2 )
+						TestClient(client);
 
 					g_smChecked.SetValue(g_sFilename, false);
 					return;


### PR DESCRIPTION
- Now only TestClient depending cvar
- Now ban lenght can be adjusted via cvar
- Now less check of GetClientAuthId by storing them.
- Switch to Steam3 format for AuthID.
- Fixed g_smWaiting not removing data for unverified clients.
- Prevent g_smWaiting not removing data if client was already disconnected.
- LogAction now print infos even if client is not verified.